### PR TITLE
[codex] Add visual model provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ recordings/*
 # Local configuration files
 app/config/config.json
 
+# Local Codex modification log
+CODEX_MODIFICATION_LOG.md
+
 # System files
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1191,85 +1191,366 @@ After an event ends, it is written into `log/ai_events.jsonl` and displayed in c
 
 ### 4.6. Third-party Model Integration (Replaceable) [⌃](#top)
 
-The current AI module is built around the vision model API provided by the Volcengine platform.  
-To use the AI functionality, you must first obtain **model access permission** and an **API Key**, then enter them into the Dashboard settings.
+Sentinel's AI module now uses a switchable visual model Provider architecture. You can switch to OpenAI, Gemini, DashScope, SiliconFlow, or other third-party / local visual model services that expose an OpenAI-compatible API through configuration.
 
-> Support for additional platforms will be added in future updates.  
-> If you wish to integrate other platforms or locally deployed vision models in the current version, modify the `analyze_frame()` function in `ai_ark.py`, and ensure the output structure complies with the Output Contract.
+> Model switching is configured through `app/config/config.json`, environment variables, or code defaults. The Dashboard already displays the currently effective model information.
 
 ---
 
-#### 4.6.1. Account Registration and Login
+#### 4.6.1. Module Structure
 
-1. Visit the platform login page: https://console.volcengine.com/  
-   If the page language is not preferred, switch via the `中文 / EN` button in the upper-right corner;
+The model replacement capability is implemented by the following files:
 
-2. Complete registration and log in to the console;
+| File | Purpose |
+|------|---------|
+| `app/ai/vision_client.py` | Unified visual model client entry point. Handles Provider resolution, client creation, and OpenAI-compatible requests. |
+| `app/ai/ai_ark.py` | Existing Ark visual model client, kept for backward compatibility. |
+| `app/ai/ai_monitor_worker.py` | AI monitoring worker. Creates the current model client through `create_vision_client()`. |
+| `app/config/config_store.py` | Adds and validates general model configuration fields. |
+| `app/web/webapp.py` | Adds sanitized `model_info` to `/api/ai/status`. |
+| `app/web/templates/dashboard.html` | Adds the Model Info block to the AI Status area. |
+| `app/web/static/dashboard.js` | Renders the current model information in the frontend. |
 
-3. Enter the `Ark` page;
+The AI model call chain is:
 
-4. Go to `Config - Model activation`, and under the “Large Language Model” category, locate the vision model.  
-   It is recommended to select `Doubao-Seed-2.0-mini`, then click the corresponding “Activate” button;
+```text
+Config source (Dashboard / config.json / env) -> ConfigStore -> resolve_provider_settings() -> create_vision_client()
+                                                              |- ArkVisionClient
+                                                              `- OpenAICompatibleVisionClient
+Visual frame FrameBuffer -> analyze_frame(frame) -> JSON result -> AI EventStore / Dashboard
+```
 
-- Reminder: Also enable the “**Free Credits Only Mode**” service on the Model activation page.  
-  The model provides a free quota (500,000 tokens). After activation, only the free quota is consumed.  
-  Once exhausted, API access will automatically be disabled.
-
-5. Go to the `Config - API keys` page in the console;
-
-6. Click “**Create API Key**” and configure as needed;
-
-7. After creation, copy and securely store the generated API Key.
-
-> As the platform UI and free quota policies may change over time, the steps above are for reference.  
-> However, the core process remains:
-
-1. Register and log in to the platform console;  
-2. Activate a vision-capable model;  
-3. Create an API Key;  
-4. Enter the Model ID and API Key into the Dashboard.
+The AI worker only depends on the unified `analyze_frame()` method, so adding more providers later does not require major changes to the state machine.
 
 ---
 
-#### 4.6.2. Model Information
+#### 4.6.2. Supported Providers
 
-Based on development testing, `Doubao-Seed-2.0-mini` currently provides the best cost-performance balance.
+Built-in Providers currently include:
 
-- Doubao-Seed-2.0-mini:
-  - Lightweight model designed for low-latency and high-concurrency scenarios;
-  - Supports up to 256k context length;
-  - Four reasoning depth levels (minimal / low / medium / high);
-  - Supports multimodal image-text understanding and function calling;
-  - In non-reasoning mode, token consumption is only 1/10 of reasoning mode, offering excellent cost efficiency for simple scenarios.
+| Provider | Type | Default Base URL | Description |
+|----------|------|------------------|-------------|
+| `ark` | Native Ark client | `https://ark.cn-beijing.volces.com/api/v3` | Keeps the existing Volcengine Ark integration. |
+| `openai` | OpenAI-compatible | `https://api.openai.com/v1` | For OpenAI Chat Completions vision models. |
+| `gemini` | OpenAI-compatible | `https://generativelanguage.googleapis.com/v1beta/openai` | For Gemini's OpenAI-compatible interface. |
+| `dashscope` | OpenAI-compatible | `https://dashscope.aliyuncs.com/compatible-mode/v1` | For Alibaba Cloud Model Studio / Qwen compatible mode. |
+| `siliconflow` | OpenAI-compatible | `https://api.siliconflow.cn/v1` | For SiliconFlow compatible mode. |
+| `openai_compatible` | OpenAI-compatible | None | For custom compatible APIs or local model gateways. |
 
-> After entering the model ID `doubao-seed-2-0-mini-260215` and your API Key into the Dashboard and applying the settings, the AI module will function properly.
-
----
-
-#### 4.6.3. Replacing the Vision Model
-
-If you wish to use other models (e.g., OpenAI Vision or a locally deployed multimodal model), modify the following files:
-
-- `ai_ark.py`
-  - Modify the `analyze_frame()` function
-  - Replace the API call logic
-  - Ensure JSON output structure remains consistent
-
-- `config_store.py` (optional)
-  - Add new model parameters
-  - Set default values
-
-The Dashboard and AI Status panels rely on the Output Contract for rendering.  
-If field names change, you must also update:
-
-- `ai_monitor_worker.py`
-- `dashboard.js`
-
-> ⚠️ Important: Regardless of the model used, the output structure must conform to the predefined Output Contract.  
-> Otherwise, the Dashboard will not be able to correctly parse the results.
+> Whether image input is supported depends on the selected model itself. Make sure `ai_model` points to a vision-capable model.
 
 ---
 
+#### 4.6.3. Configuration Fields
+
+The following general fields were added:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ai_provider` | string | `ark` | Current model provider. |
+| `ai_model` | string | empty | General model ID. If Provider is Ark and this field is empty, the system falls back to `ark_model`. |
+| `ai_base_url` | string | empty | Custom model service base URL. Some built-in Providers have default Base URLs. |
+| `ai_api_key` | string | empty | General model API Key. If empty, the system tries environment variables. |
+| `ai_request_timeout_sec` | integer | `30` | Model request timeout, allowed range 5 to 120 seconds. |
+
+For backward compatibility, these Ark fields are still supported:
+
+| Field | Description |
+|-------|-------------|
+| `ark_model` | Ark / Volcengine model ID. |
+| `ark_api_key` | Ark / Volcengine API Key. |
+
+When `ai_provider = "ark"`, model selection priority is:
+
+```text
+AI_MODEL environment variable
+  > ai_model
+  > ark_model
+```
+
+API Key priority is:
+
+```text
+AI_API_KEY environment variable
+  > ai_api_key
+  > ARK_API_KEY environment variable
+  > ark_api_key
+```
+
+---
+
+#### 4.6.4. Environment Variables
+
+Environment variables can temporarily override configuration files, which is useful for local tests or deployments.
+
+General environment variables:
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| `AI_PROVIDER` | Overrides `ai_provider`. |
+| `AI_MODEL` | Overrides `ai_model`. |
+| `AI_BASE_URL` | Overrides `ai_base_url`. |
+| `AI_API_KEY` | Overrides `ai_api_key`. |
+
+Provider-specific environment variables:
+
+| Provider | Environment Variables |
+|----------|-----------------------|
+| `ark` | `ARK_API_KEY` |
+| `openai` | `OPENAI_API_KEY` |
+| `gemini` | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
+| `dashscope` | `DASHSCOPE_API_KEY` / `QWEN_API_KEY` |
+| `siliconflow` | `SILICONFLOW_API_KEY` |
+
+---
+
+#### 4.6.5. Use the Default Ark / Volcengine Model
+
+To keep using the original Volcengine Ark model, keep the default Provider:
+
+```json
+{
+  "ai_provider": "ark",
+  "ark_model": "doubao-seed-2-0-mini-260215",
+  "ark_api_key": "YOUR_ARK_API_KEY"
+}
+```
+
+You can also use environment variables:
+
+```powershell
+$env:AI_PROVIDER = "ark"
+$env:ARK_API_KEY = "YOUR_ARK_API_KEY"
+```
+
+This is suitable when:
+
+- you want to keep using the existing Volcengine Ark model;
+- you do not want to change the existing Dashboard workflow;
+- you need backward compatibility with older configuration files.
+
+---
+
+#### 4.6.6. Use an OpenAI Vision Model
+
+Configuration example:
+
+```json
+{
+  "ai_provider": "openai",
+  "ai_model": "gpt-4o-mini",
+  "ai_api_key": "YOUR_OPENAI_API_KEY"
+}
+```
+
+Environment variable example:
+
+```powershell
+$env:AI_PROVIDER = "openai"
+$env:AI_MODEL = "gpt-4o-mini"
+$env:OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
+```
+
+The system automatically uses:
+
+```text
+https://api.openai.com/v1/chat/completions
+```
+
+---
+
+#### 4.6.7. Use Gemini OpenAI-compatible API
+
+Configuration example:
+
+```json
+{
+  "ai_provider": "gemini",
+  "ai_model": "gemini-2.5-flash",
+  "ai_api_key": "YOUR_GEMINI_API_KEY"
+}
+```
+
+Environment variable example:
+
+```powershell
+$env:AI_PROVIDER = "gemini"
+$env:AI_MODEL = "gemini-2.5-flash"
+$env:GEMINI_API_KEY = "YOUR_GEMINI_API_KEY"
+```
+
+The system automatically uses:
+
+```text
+https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+```
+
+---
+
+#### 4.6.8. Use DashScope / Qwen Compatible Mode
+
+Configuration example:
+
+```json
+{
+  "ai_provider": "dashscope",
+  "ai_model": "qwen-vl-plus",
+  "ai_api_key": "YOUR_DASHSCOPE_API_KEY"
+}
+```
+
+Environment variable example:
+
+```powershell
+$env:AI_PROVIDER = "dashscope"
+$env:AI_MODEL = "qwen-vl-plus"
+$env:DASHSCOPE_API_KEY = "YOUR_DASHSCOPE_API_KEY"
+```
+
+The system automatically uses:
+
+```text
+https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+```
+
+---
+
+#### 4.6.9. Use a Custom OpenAI-compatible Service
+
+For a third-party relay service, local model gateway, or self-hosted compatible service, use:
+
+```json
+{
+  "ai_provider": "openai_compatible",
+  "ai_model": "your-vision-model",
+  "ai_base_url": "http://127.0.0.1:9000/v1",
+  "ai_api_key": "YOUR_API_KEY"
+}
+```
+
+The final request URL is automatically resolved to:
+
+```text
+http://127.0.0.1:9000/v1/chat/completions
+```
+
+If `ai_base_url` already points to the full endpoint:
+
+```json
+{
+  "ai_base_url": "http://127.0.0.1:9000/v1/chat/completions"
+}
+```
+
+The system uses that endpoint directly and does not append the path again.
+
+---
+
+#### 4.6.10. Current Model Info in Dashboard
+
+The AI Status area in Dashboard now includes a `Model Info` block showing the effective backend model settings.
+
+Example:
+
+```text
+Provider: openai
+Client:   openai_compatible
+Model:    gpt-4o-mini
+Base URL: https://api.openai.com/v1
+API Key:  configured
+Timeout:  30s
+```
+
+Field description:
+
+| Item | Description |
+|------|-------------|
+| `Provider` | Current model platform. |
+| `Client` | Actual backend client type. |
+| `Model` | Current model ID. |
+| `Base URL` | Current request base URL. |
+| `API Key` | Shows only whether a key is configured. The real key is never returned. |
+| `Timeout` | Request timeout. |
+
+If the API Key is missing, Dashboard shows:
+
+```text
+API Key: missing
+```
+
+In this state, AI model calls will not work, but basic video upload, preview, recording, and snapshot functions are not affected.
+
+---
+
+#### 4.6.11. Model Output Format
+
+Regardless of the Provider, model output must be parseable as one JSON object.
+
+The current system expects these fields:
+
+```json
+{
+  "has_person": true,
+  "person_count": 1,
+  "activity": "standing",
+  "risk_level": "info",
+  "summary": "A person is standing in the monitored area.",
+  "confidence": 0.87
+}
+```
+
+Field description:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `has_person` | boolean | Whether a person appears in the frame. |
+| `person_count` | number or null | Number of people. |
+| `activity` | string | Activity state, such as `passing` / `standing` / `lingering` / `unknown`. |
+| `risk_level` | string | Suggested values: `info` / `warn` / `critical`. |
+| `summary` | string | Short description. |
+| `confidence` | number | Confidence score from 0 to 1. |
+
+If some fields are missing, the system tries to fill defaults. For stable behavior, it is still recommended to require the model to output only JSON in the prompt:
+
+```text
+Only output one JSON object. Do not output markdown or extra explanations.
+```
+
+---
+
+#### 4.6.12. Verification and Tests
+
+Automated tests have been added for this module, covering:
+
+- Provider configuration resolution;
+- Ark legacy field compatibility;
+- Base URL resolution to `/chat/completions`;
+- OpenAI-compatible response parsing;
+- sanitized model information output;
+- Dashboard Model Info container rendering;
+- a complete request chain against a local fake OpenAI-compatible vision service.
+
+Run tests:
+
+```powershell
+python -m pytest -q
+```
+
+Current verification result:
+
+```text
+12 passed
+```
+
+The local fake model service test verifies that:
+
+- the request path is `/v1/chat/completions`;
+- `Authorization: Bearer ...` is sent;
+- the request body contains the correct `model`;
+- the image is sent as `data:image/jpeg;base64,...`;
+- the model JSON output can be parsed and normalized by the system.
+
+---
 <a id="sec5"></a>
 
 ## 5. Version Information & Notes [⌃](#top)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1183,68 +1183,366 @@ Event duration: 153.9 s
 
 ### 4.6. 第三方模型调用（可替换） [⌃](#top)
 
-当前系统的 AI 模块围绕 火山引擎 平台提供的视觉模型 API 构建，如需使用系统的 AI 功能，请先至平台获得 **模型权限** 与 **API KEY**，填入设置配置中才能正常启用。
+Sentinel 的 AI 模块为可切换的视觉模型 Provider 架构。可以通过配置切换到 OpenAI、Gemini、DashScope、SiliconFlow，或其他提供 OpenAI-compatible 接口的第三方 / 本地视觉模型服务。
 
-> 其他平台模型的接入会在后续的更新中进行兼容，当下版本如需接入其他平台或本地部署视觉模型，请修改 `ai_ark.py` 中的 `analyze_frame()` 函数，并确保输出结构符合字段合同。
-
----
-
-#### 4.6.1. 账号注册与登录
-
-1. 访问平台登录页面 https://console.volcengine.com/ ，若页面语言非使用者语言，请点击右上角 `中文 / EN` 按钮进行切换；
-2. 按页面指引完成注册后登录控制台；
-3. 在控制台进入 `火山方舟` 页面；
-4. 进入`开通管理`页面，在「大语言模型」分类下找到视觉模型，推荐选择 `Doubao-Seed-2.0-mini` 模型，点击对应「开通」按钮；
-
-- 提醒：在`开通管理`页面中也同时开启「安心体验」服务，模型提供免费额度（50万 tokens），开通后只消耗免费额度，额度耗尽后将自动转关闭接口权限。
-
-5. 进入控制台的 `API Key 管理` 页面；
-6. 点击「新建 API Key」，按需求配置；
-7. 配置完成后点击「确认创建」，复制生成的 API Key 并妥善保存。
-
-> 考虑到 平台的 UI 、免费额度等参照可能随时间而变化，上述步骤仅作参考，但核心环节不变：
-
-1. 注册并登录平台控制台；
-2. 开通支持视觉能力的模型；
-3. 创建 API Key；
-4. 将 Model ID 与 API Key 填入 Dashboard。
+> 模型切换通过 `app/config/config.json`、环境变量或代码默认配置完成。Dashboard 已支持显示当前生效模型信息。
 
 ---
 
-#### 4.6.2. 模型信息
+#### 4.6.1. 模块结构
 
-根据开发测试，现阶段使用 `Doubao-Seed-2.0-mini` 的性价比相对最高。
+本次模型替换能力由以下文件协同实现：
 
-- Doubao-Seed-2.0-mini：
-  - 面向低时延、高并发场景的轻量级模型；
-  - 支持 256k 上下文长度；
-  - 4 档思考深度调节（minimal/low/medium/high）；
-  - 支持图文多模态理解、函数调用能力，适合成本速度优先的轻量级任务；
-  - 非思考模式下 tokens 消耗量仅为思考模式的 1/10，简单场景性价比极高。
+| 文件 | 作用 |
+|------|------|
+| `app/ai/vision_client.py` | 统一视觉模型客户端入口，负责 Provider 解析、客户端创建与 OpenAI-compatible 请求 |
+| `app/ai/ai_ark.py` | 原 Ark 视觉模型客户端，继续保留 |
+| `app/ai/ai_monitor_worker.py` | AI 监控线程，通过 `create_vision_client()` 创建当前模型客户端 |
+| `app/config/config_store.py` | 新增通用模型配置字段与校验逻辑 |
+| `app/web/webapp.py` | `/api/ai/status` 返回脱敏后的 `model_info` |
+| `app/web/templates/dashboard.html` | AI Status 区域新增 Model Info 显示块 |
+| `app/web/static/dashboard.js` | 前端渲染当前模型信息 |
 
-> 在将模型 ID —— doubao-seed-2-0-mini-260215 与 自己的 API Key 填写进 Dashboard 后并应用设置，AI 模块正式可以工作。
+AI 模型调用链路如下：
 
----
+```text
+配置来源（Dashboard / config.json / env）→ ConfigStore → resolve_provider_settings() → create_vision_client()
+                                                          ├─ ArkVisionClient
+                                                          └─ OpenAICompatibleVisionClient
+视觉帧 FrameBuffer → analyze_frame(frame) → JSON result → AI EventStore / Dashboard
+```
 
-#### 4.6.3. 替换视觉模型
-
-若希望使用其他模型（例如 OpenAI Vision 或本地多模态模型），请修改以下文件：
-
-- `ai_ark.py`
-  - 修改 `analyze_frame()` 函数
-  - 替换 API 调用逻辑
-  - 保持输出 JSON 字段结构一致
-
-- `config_store.py`（可选）
-  - 添加新的模型参数
-  - 设置默认值
-
-而 Dashboard 与 AI Status 区域也依赖该字段合同进行渲染。若字段名改变，则必须同步修改：`ai_monitor_worker.py`，`dashboard.js` 中对字段的描述。
-
-> ⚠️ 重要：无论更换何种模型，必须保证输出结构符合设定的字段合同。否则 Dashboard 无法正确对模型结果进行解析。
+AI worker 只依赖统一的 `analyze_frame()` 方法，因此后续继续增加新平台时，不需要大幅修改状态机逻辑。
 
 ---
 
+#### 4.6.2. 当前支持的 Provider
+
+当前内置 Provider 包括：
+
+| Provider | 类型 | 默认 Base URL | 说明 |
+|----------|------|---------------|------|
+| `ark` | Ark 原生客户端 | `https://ark.cn-beijing.volces.com/api/v3` | 保留原有火山方舟调用方式 |
+| `openai` | OpenAI-compatible | `https://api.openai.com/v1` | 用于 OpenAI Chat Completions 视觉模型 |
+| `gemini` | OpenAI-compatible | `https://generativelanguage.googleapis.com/v1beta/openai` | 用于 Gemini OpenAI 兼容接口 |
+| `dashscope` | OpenAI-compatible | `https://dashscope.aliyuncs.com/compatible-mode/v1` | 用于阿里云百炼 / 通义千问兼容接口 |
+| `siliconflow` | OpenAI-compatible | `https://api.siliconflow.cn/v1` | 用于 SiliconFlow 兼容接口 |
+| `openai_compatible` | OpenAI-compatible | 无默认值 | 用于自定义兼容接口或本地模型网关 |
+
+> 注意：不同平台是否支持图像输入，取决于所选模型本身。请确保 `ai_model` 指向的是具备视觉理解能力的模型。
+
+---
+
+#### 4.6.3. 配置字段说明
+
+本次新增以下通用字段：
+
+| 字段名 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `ai_provider` | 字符串 | `ark` | 当前使用的模型平台 |
+| `ai_model` | 字符串 | 空 | 通用模型 ID。若 Provider 为 Ark 且该字段为空，会回退使用 `ark_model` |
+| `ai_base_url` | 字符串 | 空 | 自定义模型服务地址。部分内置 Provider 有默认 Base URL |
+| `ai_api_key` | 字符串 | 空 | 通用模型 API Key。若为空，会尝试读取环境变量 |
+| `ai_request_timeout_sec` | 整数 | `30` | 模型请求超时时间，允许范围为 5 到 120 秒 |
+
+为兼容旧版本配置，以下 Ark 字段仍然可用：
+
+| 字段名 | 说明 |
+|--------|------|
+| `ark_model` | Ark / 火山方舟模型 ID |
+| `ark_api_key` | Ark / 火山方舟 API Key |
+
+当 `ai_provider = "ark"` 时，模型选择优先级为：
+
+```text
+AI_MODEL 环境变量
+  > ai_model
+  > ark_model
+```
+
+API Key 选择优先级为：
+
+```text
+AI_API_KEY 环境变量
+  > ai_api_key
+  > ARK_API_KEY 环境变量
+  > ark_api_key
+```
+
+---
+
+#### 4.6.4. 环境变量说明
+
+系统支持通过环境变量临时覆盖配置文件，适合本地测试或部署环境使用。
+
+通用环境变量：
+
+| 环境变量 | 说明 |
+|----------|------|
+| `AI_PROVIDER` | 覆盖 `ai_provider` |
+| `AI_MODEL` | 覆盖 `ai_model` |
+| `AI_BASE_URL` | 覆盖 `ai_base_url` |
+| `AI_API_KEY` | 覆盖 `ai_api_key` |
+
+Provider 专用环境变量：
+
+| Provider | 支持的环境变量 |
+|----------|----------------|
+| `ark` | `ARK_API_KEY` |
+| `openai` | `OPENAI_API_KEY` |
+| `gemini` | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
+| `dashscope` | `DASHSCOPE_API_KEY` / `QWEN_API_KEY` |
+| `siliconflow` | `SILICONFLOW_API_KEY` |
+
+---
+
+#### 4.6.5. 使用默认 Ark / 火山方舟模型
+
+如果希望继续使用原有火山方舟模型，可保持默认 Provider：
+
+```json
+{
+  "ai_provider": "ark",
+  "ark_model": "doubao-seed-2-0-mini-260215",
+  "ark_api_key": "YOUR_ARK_API_KEY"
+}
+```
+
+也可以使用环境变量：
+
+```powershell
+$env:AI_PROVIDER = "ark"
+$env:ARK_API_KEY = "YOUR_ARK_API_KEY"
+```
+
+适用场景：
+
+- 希望继续使用原有火山方舟模型；
+- 不希望改动原有 Dashboard 使用习惯；
+- 需要保持旧配置兼容。
+
+---
+
+#### 4.6.6. 使用 OpenAI 视觉模型
+
+配置示例：
+
+```json
+{
+  "ai_provider": "openai",
+  "ai_model": "gpt-4o-mini",
+  "ai_api_key": "YOUR_OPENAI_API_KEY"
+}
+```
+
+环境变量示例：
+
+```powershell
+$env:AI_PROVIDER = "openai"
+$env:AI_MODEL = "gpt-4o-mini"
+$env:OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
+```
+
+系统会自动使用：
+
+```text
+https://api.openai.com/v1/chat/completions
+```
+
+---
+
+#### 4.6.7. 使用 Gemini OpenAI-compatible 接口
+
+配置示例：
+
+```json
+{
+  "ai_provider": "gemini",
+  "ai_model": "gemini-2.5-flash",
+  "ai_api_key": "YOUR_GEMINI_API_KEY"
+}
+```
+
+环境变量示例：
+
+```powershell
+$env:AI_PROVIDER = "gemini"
+$env:AI_MODEL = "gemini-2.5-flash"
+$env:GEMINI_API_KEY = "YOUR_GEMINI_API_KEY"
+```
+
+系统会自动使用：
+
+```text
+https://generativelanguage.googleapis.com/v1beta/openai/chat/completions
+```
+
+---
+
+#### 4.6.8. 使用 DashScope / 通义千问兼容接口
+
+配置示例：
+
+```json
+{
+  "ai_provider": "dashscope",
+  "ai_model": "qwen-vl-plus",
+  "ai_api_key": "YOUR_DASHSCOPE_API_KEY"
+}
+```
+
+环境变量示例：
+
+```powershell
+$env:AI_PROVIDER = "dashscope"
+$env:AI_MODEL = "qwen-vl-plus"
+$env:DASHSCOPE_API_KEY = "YOUR_DASHSCOPE_API_KEY"
+```
+
+系统会自动使用：
+
+```text
+https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions
+```
+
+---
+
+#### 4.6.9. 使用自定义 OpenAI-compatible 服务
+
+若使用第三方中转服务、本地模型网关或自建兼容服务，可使用：
+
+```json
+{
+  "ai_provider": "openai_compatible",
+  "ai_model": "your-vision-model",
+  "ai_base_url": "http://127.0.0.1:9000/v1",
+  "ai_api_key": "YOUR_API_KEY"
+}
+```
+
+系统最终请求地址会自动拼接为：
+
+```text
+http://127.0.0.1:9000/v1/chat/completions
+```
+
+如果 `ai_base_url` 已经写到完整接口：
+
+```json
+{
+  "ai_base_url": "http://127.0.0.1:9000/v1/chat/completions"
+}
+```
+
+系统会直接使用该地址，不会重复拼接。
+
+---
+
+#### 4.6.10. Dashboard 当前模型信息
+
+Dashboard 的 AI Status 区域新增了 `Model Info` 显示块，用于展示当前后端实际生效的模型配置。
+
+显示内容示例：
+
+```text
+Provider: openai
+Client:   openai_compatible
+Model:    gpt-4o-mini
+Base URL: https://api.openai.com/v1
+API Key:  configured
+Timeout:  30s
+```
+
+字段说明：
+
+| 显示项 | 说明 |
+|--------|------|
+| `Provider` | 当前选择的模型平台 |
+| `Client` | 后端实际使用的客户端类型 |
+| `Model` | 当前模型 ID |
+| `Base URL` | 当前请求的基础地址 |
+| `API Key` | 只显示是否已配置，不显示真实 Key |
+| `Timeout` | 请求超时时间 |
+
+若 API Key 缺失，Dashboard 会显示：
+
+```text
+API Key: missing
+```
+
+此时 AI 模型调用不会正常进行，但基础的视频上传、预览、录制等功能不受影响。
+
+---
+
+#### 4.6.11. 模型输出格式要求
+
+无论使用哪一个模型平台，模型返回内容都必须能解析为一个 JSON 对象。
+
+当前系统要求模型输出以下字段：
+
+```json
+{
+  "has_person": true,
+  "person_count": 1,
+  "activity": "standing",
+  "risk_level": "info",
+  "summary": "A person is standing in the monitored area.",
+  "confidence": 0.87
+}
+```
+
+字段说明：
+
+| 字段名 | 类型 | 说明 |
+|--------|------|------|
+| `has_person` | boolean | 画面中是否有人 |
+| `person_count` | number 或 null | 人数 |
+| `activity` | string | 活动状态，如 `passing` / `standing` / `lingering` / `unknown` |
+| `risk_level` | string | 风险等级，建议为 `info` / `warn` / `critical` |
+| `summary` | string | 简短描述 |
+| `confidence` | number | 置信度，范围 0 到 1 |
+
+如果模型返回结果中缺少部分字段，系统会尝试补默认值；但为了获得稳定结果，建议在 Prompt 中明确要求模型：
+
+```text
+Only output one JSON object. Do not output markdown or extra explanations.
+```
+
+---
+
+#### 4.6.12. 验证与测试
+
+本模块已添加自动化测试，主要覆盖：
+
+- Provider 配置解析；
+- Ark 旧字段兼容；
+- Base URL 到 `/chat/completions` 的拼接逻辑；
+- OpenAI-compatible 响应解析；
+- API Key 脱敏模型信息输出；
+- Dashboard 是否包含 Model Info 容器；
+- 使用本地假 OpenAI-compatible 服务完整验证请求链路。
+
+运行测试：
+
+```powershell
+python -m pytest -q
+```
+
+当前验证结果：
+
+```text
+12 passed
+```
+
+其中，本地假模型服务测试会验证：
+
+- 请求地址是否为 `/v1/chat/completions`；
+- 是否携带 `Authorization: Bearer ...`；
+- 请求体中的 `model` 是否正确；
+- 图像是否以 `data:image/jpeg;base64,...` 形式传递；
+- 模型 JSON 输出是否能被系统解析并归一化。
+
+---
 <a id="sec5"></a>
 
 ## 5. 版本信息与项目说明 [⌃](#top)

--- a/app/ai/ai_monitor_worker.py
+++ b/app/ai/ai_monitor_worker.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from .ai_store import AiRuntime, EventStore
 from .motion_trigger import MotionTrigger
-from .ai_ark import ArkVisionClient, resolve_api_key
+from .vision_client import client_signature, create_vision_client, resolve_provider_settings
 
 
 def _now_text() -> str:
@@ -45,11 +45,10 @@ def ai_monitor_loop(cfg_store, frame_buf, ai_rt: AiRuntime, event_store: EventSt
       - Use has_person to confirm dwell >= threshold and to decide event end.
     """
     motion = MotionTrigger()
-    client: Optional[ArkVisionClient] = None
+    client = None
 
     # Cache to avoid recreating client on every loop.
-    last_model = None
-    last_key = None
+    last_client_sig: Optional[str] = None
 
     while not stop_event.is_set():
         cfg = cfg_store.get_copy()
@@ -70,24 +69,33 @@ def ai_monitor_loop(cfg_store, frame_buf, ai_rt: AiRuntime, event_store: EventSt
         motion.ratio_threshold = _clamp_float(cfg.get("motion_ratio_threshold", 0.02), 0.001, 0.5, 0.02)
         motion.min_trigger_interval_sec = _clamp_float(cfg.get("motion_min_interval", 1.0), 0.1, 10.0, 1.0)
 
-        ark_model = str(cfg.get("ark_model", "")).strip()
-        api_key = resolve_api_key(cfg).strip()
-
-        if not ark_model or not api_key:
+        settings = resolve_provider_settings(cfg)
+        if not settings["model"] or not settings["api_key"]:
+            missing = []
+            if not settings["model"]:
+                missing.append("model")
+            if not settings["api_key"]:
+                missing.append("api_key")
+            with ai_rt.lock:
+                ai_rt.last_ai_error = f"AI config missing: {', '.join(missing)}"
             time.sleep(0.2)
             continue
 
         # Initialize / rebuild client if config changed
-        if client is None or ark_model != last_model or api_key != last_key:
+        sig = client_signature(cfg)
+        if client is None or sig != last_client_sig:
             try:
-                client = ArkVisionClient(api_key=api_key, model=ark_model)
-                last_model = ark_model
-                last_key = api_key
-                logger.info("ArkVisionClient ready")
+                client = create_vision_client(cfg)
+                last_client_sig = sig
+                with ai_rt.lock:
+                    ai_rt.last_ai_error = ""
+                logger.info(
+                    f"Vision client ready: provider={settings['provider']} model={settings['model']}"
+                )
             except Exception as e:
                 with ai_rt.lock:
-                    ai_rt.last_ai_error = f"Ark init failed: {e}"
-                logger.error(f"Ark init failed: {e}")
+                    ai_rt.last_ai_error = f"Vision client init failed: {e}"
+                logger.error(f"Vision client init failed: {e}")
                 client = None
                 time.sleep(1.0)
                 continue

--- a/app/ai/vision_client.py
+++ b/app/ai/vision_client.py
@@ -1,0 +1,276 @@
+# pc/app/ai/vision_client.py
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from .ai_ark import (
+    ArkVisionClient,
+    _extract_json,
+    _frame_to_data_url_jpeg,
+    _resize_for_ai,
+    resolve_api_key,
+)
+
+
+PROVIDER_PRESETS: Dict[str, Dict[str, Any]] = {
+    "openai": {
+        "kind": "openai_compatible",
+        "base_url": "https://api.openai.com/v1",
+        "env_keys": ["OPENAI_API_KEY"],
+    },
+    "dashscope": {
+        "kind": "openai_compatible",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "env_keys": ["DASHSCOPE_API_KEY", "QWEN_API_KEY"],
+    },
+    "gemini": {
+        "kind": "openai_compatible",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "env_keys": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    },
+    "siliconflow": {
+        "kind": "openai_compatible",
+        "base_url": "https://api.siliconflow.cn/v1",
+        "env_keys": ["SILICONFLOW_API_KEY"],
+    },
+    "openai_compatible": {
+        "kind": "openai_compatible",
+        "base_url": "",
+        "env_keys": ["AI_API_KEY", "OPENAI_API_KEY"],
+    },
+    "ark": {
+        "kind": "ark",
+        "base_url": "",
+        "env_keys": ["ARK_API_KEY"],
+    },
+}
+
+
+def _clean_provider(provider: Any) -> str:
+    name = str(provider or "ark").strip().lower().replace("-", "_")
+    return name or "ark"
+
+
+def _first_env(names: List[str]) -> str:
+    for name in names:
+        val = os.environ.get(name)
+        if val:
+            return val.strip()
+    return ""
+
+
+def _join_chat_url(base_url: str) -> str:
+    base = str(base_url or "").strip()
+    if not base:
+        raise ValueError("ai_base_url is required for openai_compatible provider")
+    base = base.rstrip("/")
+    if base.endswith("/chat/completions"):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/chat/completions"
+    return f"{base}/v1/chat/completions"
+
+
+def resolve_provider_settings(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    provider = _clean_provider(os.environ.get("AI_PROVIDER") or cfg.get("ai_provider") or "ark")
+    preset = PROVIDER_PRESETS.get(provider)
+    if preset is None:
+        if provider == "volcengine":
+            provider = "ark"
+            preset = PROVIDER_PRESETS[provider]
+        else:
+            preset = PROVIDER_PRESETS["openai_compatible"]
+
+    kind = preset["kind"]
+    model = str(os.environ.get("AI_MODEL") or cfg.get("ai_model") or "").strip()
+    base_url = str(os.environ.get("AI_BASE_URL") or cfg.get("ai_base_url") or preset.get("base_url") or "").strip()
+    api_key = str(os.environ.get("AI_API_KEY") or cfg.get("ai_api_key") or "").strip()
+    if not api_key:
+        api_key = _first_env(list(preset.get("env_keys") or []))
+
+    if kind == "ark":
+        model = model or str(cfg.get("ark_model", "")).strip()
+        api_key = api_key or resolve_api_key(cfg).strip()
+        base_url = base_url or "https://ark.cn-beijing.volces.com/api/v3"
+
+    timeout_sec = cfg.get("ai_request_timeout_sec", 30)
+    try:
+        timeout_sec = int(timeout_sec)
+    except Exception:
+        timeout_sec = 30
+    timeout_sec = max(5, min(120, timeout_sec))
+
+    return {
+        "provider": provider,
+        "kind": kind,
+        "model": model,
+        "base_url": base_url,
+        "api_key": api_key,
+        "timeout_sec": timeout_sec,
+    }
+
+
+def safe_provider_info(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return current effective model settings without exposing API keys."""
+    settings = resolve_provider_settings(cfg)
+    return {
+        "provider": settings["provider"],
+        "kind": settings["kind"],
+        "model": settings["model"],
+        "base_url": settings["base_url"],
+        "timeout_sec": settings["timeout_sec"],
+        "api_key_set": bool(settings["api_key"]),
+    }
+
+
+class OpenAICompatibleVisionClient:
+    """
+    Vision client for providers that expose OpenAI-compatible Chat Completions.
+
+    Supported examples include OpenAI, DashScope compatible mode, Gemini OpenAI
+    compatibility, SiliconFlow, and other services exposing /v1/chat/completions.
+    """
+
+    def __init__(self, api_key: str, model: str, base_url: str, timeout_sec: int = 30):
+        self.api_key = api_key
+        self.model = model
+        self.base_url = base_url
+        self.timeout_sec = timeout_sec
+        self.chat_url = _join_chat_url(base_url)
+
+    @staticmethod
+    def build_prompt_contract() -> str:
+        return ArkVisionClient.build_prompt_contract()
+
+    def analyze_frame(
+        self,
+        frame_bgr,
+        time_text: str,
+        prompt_template: str = "",
+        scene_profile: str = "",
+        session_focus: str = "",
+        extra_prompt: str = "",
+        jpeg_quality: int = 85,
+        max_w: int = 640,
+    ) -> Dict[str, Any]:
+        frame_bgr = _resize_for_ai(frame_bgr, max_w=max_w)
+        data_url = _frame_to_data_url_jpeg(frame_bgr, jpeg_quality=jpeg_quality)
+
+        prompt_parts = [f"Current time: {time_text}"]
+        if prompt_template:
+            prompt_parts.append(f"Role: {prompt_template}")
+        if scene_profile:
+            prompt_parts.append(f"Long-term scene profile: {scene_profile}")
+        if session_focus:
+            prompt_parts.append(f"Session focus: {session_focus}")
+        if extra_prompt:
+            prompt_parts.append(f"Extra rules/notes: {extra_prompt}")
+        prompt_parts.append(self.build_prompt_contract())
+        prompt_parts.append("Based on the CCTV frame, output the JSON now.")
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "\n\n".join(prompt_parts)},
+                        {"type": "image_url", "image_url": {"url": data_url, "detail": "high"}},
+                    ],
+                }
+            ],
+        }
+
+        req = urllib.request.Request(
+            self.chat_url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout_sec) as resp:
+                body = resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"{e.code} from vision provider: {err_body[:500]}") from e
+
+        data = json.loads(body)
+        out_text = _extract_message_content(data)
+        parsed = _extract_json(out_text)
+        return _normalize_ai_json(parsed)
+
+
+def _extract_message_content(data: Dict[str, Any]) -> str:
+    choices = data.get("choices") or []
+    if not choices:
+        raise ValueError("provider response has no choices")
+
+    msg = (choices[0] or {}).get("message") or {}
+    content = msg.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(str(item.get("text", "")))
+        return "\n".join(parts)
+    return str(content)
+
+
+def _normalize_ai_json(parsed: Dict[str, Any]) -> Dict[str, Any]:
+    parsed = dict(parsed or {})
+    parsed.setdefault("has_person", False)
+    parsed.setdefault("person_count", None)
+    parsed.setdefault("activity", "unknown")
+    parsed.setdefault("risk_level", "info")
+    parsed.setdefault("summary", "")
+    parsed.setdefault("confidence", 0.0)
+
+    parsed["has_person"] = bool(parsed.get("has_person", False))
+    try:
+        c = float(parsed.get("confidence", 0.0) or 0.0)
+        parsed["confidence"] = max(0.0, min(1.0, c))
+    except Exception:
+        parsed["confidence"] = 0.0
+    return parsed
+
+
+def create_vision_client(cfg: Dict[str, Any]):
+    settings = resolve_provider_settings(cfg)
+    if not settings["model"]:
+        raise ValueError("AI model is required")
+    if not settings["api_key"]:
+        raise ValueError("AI API key is required")
+
+    if settings["kind"] == "ark":
+        return ArkVisionClient(
+            api_key=settings["api_key"],
+            model=settings["model"],
+            timeout_sec=settings["timeout_sec"],
+            base_url=settings["base_url"],
+        )
+
+    return OpenAICompatibleVisionClient(
+        api_key=settings["api_key"],
+        model=settings["model"],
+        base_url=settings["base_url"],
+        timeout_sec=settings["timeout_sec"],
+    )
+
+
+def client_signature(cfg: Dict[str, Any]) -> str:
+    settings = resolve_provider_settings(cfg)
+    return "|".join([
+        settings["provider"],
+        settings["kind"],
+        settings["model"],
+        settings["base_url"],
+        "key" if settings["api_key"] else "nokey",
+        str(settings["timeout_sec"]),
+    ])

--- a/app/config/config_store.py
+++ b/app/config/config_store.py
@@ -33,6 +33,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "ai_mode": "triggered",
 
     # Ark / Volcengine
+    "ai_provider": "ark",
+    "ai_model": "",
+    "ai_base_url": "",
+    "ai_api_key": "",
+    "ai_request_timeout_sec": 30,
     "ark_model": "doubao-seed-2-0-mini-260215",
     "ark_api_key": API_KEY,  # can also be supplied via env var ARK_API_KEY
 
@@ -132,6 +137,11 @@ def validate_and_normalize(patch: dict) -> Tuple[bool, dict, str]:
         # AI switches
         _bool("ai_enabled")
         _str("ai_mode", 30)
+        _str("ai_provider", 50)
+        _str("ai_model", 200)
+        _str("ai_base_url", 300)
+        _str("ai_api_key", 300)
+        _int("ai_request_timeout_sec", 5, 120)
 
         # Ark config
         _str("ark_model", 200)

--- a/app/web/static/dashboard.js
+++ b/app/web/static/dashboard.js
@@ -171,6 +171,7 @@ async function refreshAI() {
   const elLastSummary = document.getElementById("aiLastSummary");
   const elTimes = document.getElementById("aiTimes");
   const elMetrics = document.getElementById("aiMetrics");
+  const elModelInfo = document.getElementById("aiModelInfo");
 
   if (!(r.json && r.json.ok)) {
     const errObj = r.json || {error: r.status};
@@ -182,6 +183,7 @@ async function refreshAI() {
 
   const data = r.json.data || {};
   if (rawPre) rawPre.textContent = JSON.stringify(data, null, 2);
+  if (elModelInfo) elModelInfo.textContent = _formatModelInfo(data.model_info || {});
 
   const state = String(data.state || "?");
   const eventId = data.event_id || "—";
@@ -244,6 +246,23 @@ async function refreshAI() {
     elMetrics.textContent =
       `Person present (acc): ${accTxt}\nEvent duration:      ${durTxt}`;
   }
+}
+
+function _formatModelInfo(info) {
+  const provider = info.provider || "N/A";
+  const kind = info.kind || "N/A";
+  const model = info.model || "N/A";
+  const baseUrl = info.base_url || "N/A";
+  const timeout = info.timeout_sec ?? "N/A";
+  const keyState = info.api_key_set ? "configured" : "missing";
+  return [
+    `Provider: ${provider}`,
+    `Client:   ${kind}`,
+    `Model:    ${model}`,
+    `Base URL: ${baseUrl}`,
+    `API Key:  ${keyState}`,
+    `Timeout:  ${timeout}s`
+  ].join("\n");
 }
 
 

--- a/app/web/templates/dashboard.html
+++ b/app/web/templates/dashboard.html
@@ -233,6 +233,11 @@
               </div>
 
               <div class="ai-status-section">
+                <div class="ai-status-title">Model Info</div>
+                <div id="aiModelInfo" class="ai-kv">loading...</div>
+              </div>
+
+              <div class="ai-status-section">
                 <div class="ai-status-title">Last AI Result</div>
                 <div id="aiLastLine" class="ai-history-list">waiting…</div>
                 <div id="aiLastSummary" class="ai-history-list"></div>

--- a/app/web/webapp.py
+++ b/app/web/webapp.py
@@ -9,6 +9,7 @@ import numpy as np
 from flask import Flask, request, Response, jsonify, render_template
 
 from app.config.config_store import validate_and_normalize
+from app.ai.vision_client import safe_provider_info
 from app.recorder.recorder_worker import stop_recorder
 
 def create_app(cfg_store, frame_buf, stats, rec_rt, ai_rt, event_store, logger, stop_event, threads, server_log_path: str) -> Flask:
@@ -102,6 +103,10 @@ def create_app(cfg_store, frame_buf, stats, rec_rt, ai_rt, event_store, logger, 
             cfg["ark_api_key"] = "******"
         else:
             cfg["ark_api_key"] = ""
+        if cfg.get("ai_api_key"):
+            cfg["ai_api_key"] = "******"
+        else:
+            cfg["ai_api_key"] = ""
         return jsonify(cfg)
 
     @app.put("/api/config")
@@ -113,6 +118,10 @@ def create_app(cfg_store, frame_buf, stats, rec_rt, ai_rt, event_store, logger, 
             v = patch.get("ark_api_key")
             if v is None or str(v).strip() in ("", "******"):
                 patch.pop("ark_api_key", None)
+        if "ai_api_key" in patch:
+            v = patch.get("ai_api_key")
+            if v is None or str(v).strip() in ("", "******"):
+                patch.pop("ai_api_key", None)
 
         ok, cleaned, err = validate_and_normalize(patch)
         if not ok:
@@ -318,6 +327,7 @@ def create_app(cfg_store, frame_buf, stats, rec_rt, ai_rt, event_store, logger, 
         # Return AI thread runtime state (SLEEP/OBSERVE, event id, dwell seconds, last model output, etc.)
         try:
             snap = ai_rt.snapshot()
+            snap["model_info"] = safe_provider_info(cfg_store.get_copy())
         except Exception as e:
             return jsonify({"ok": False, "error": str(e)}), 500
         return jsonify({"ok": True, "data": snap})

--- a/tests/test_vision_client.py
+++ b/tests/test_vision_client.py
@@ -1,0 +1,183 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import numpy as np
+import pytest
+
+from app.ai.vision_client import (
+    OpenAICompatibleVisionClient,
+    _extract_message_content,
+    _join_chat_url,
+    _normalize_ai_json,
+    resolve_provider_settings,
+    safe_provider_info,
+)
+
+
+class _FakeVisionHandler(BaseHTTPRequestHandler):
+    seen = {}
+
+    def log_message(self, format, *args):
+        return
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        payload = json.loads(body.decode("utf-8"))
+
+        _FakeVisionHandler.seen = {
+            "path": self.path,
+            "auth": self.headers.get("Authorization"),
+            "model": payload.get("model"),
+            "content": payload["messages"][0]["content"],
+        }
+
+        resp = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps({
+                            "has_person": True,
+                            "person_count": 1,
+                            "activity": "standing",
+                            "risk_level": "info",
+                            "summary": "fake response",
+                            "confidence": 0.87,
+                        })
+                    }
+                }
+            ]
+        }
+        data = json.dumps(resp).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def _serve_fake_vision():
+    server = HTTPServer(("127.0.0.1", 0), _FakeVisionHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_openai_provider_uses_preset_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg = {
+        "ai_provider": "openai",
+        "ai_model": "gpt-vision-test",
+        "ai_request_timeout_sec": 30,
+    }
+
+    settings = resolve_provider_settings(cfg)
+
+    assert settings["kind"] == "openai_compatible"
+    assert settings["base_url"] == "https://api.openai.com/v1"
+    assert settings["api_key"] == "sk-test"
+    assert settings["model"] == "gpt-vision-test"
+
+
+def test_ark_keeps_legacy_model_and_key(monkeypatch):
+    monkeypatch.delenv("AI_API_KEY", raising=False)
+    monkeypatch.delenv("ARK_API_KEY", raising=False)
+    cfg = {
+        "ai_provider": "ark",
+        "ark_model": "doubao-test",
+        "ark_api_key": "ark-test",
+        "ai_request_timeout_sec": 30,
+    }
+
+    settings = resolve_provider_settings(cfg)
+
+    assert settings["kind"] == "ark"
+    assert settings["model"] == "doubao-test"
+    assert settings["api_key"] == "ark-test"
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("https://api.example.com/v1", "https://api.example.com/v1/chat/completions"),
+        ("https://api.example.com", "https://api.example.com/v1/chat/completions"),
+        ("https://api.example.com/v1/chat/completions", "https://api.example.com/v1/chat/completions"),
+    ],
+)
+def test_join_chat_url(base_url, expected):
+    assert _join_chat_url(base_url) == expected
+
+
+def test_extract_message_content_supports_string_and_parts():
+    assert _extract_message_content({"choices": [{"message": {"content": "hello"}}]}) == "hello"
+    assert _extract_message_content({
+        "choices": [
+            {
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,x"}},
+                        {"type": "text", "text": "world"},
+                    ]
+                }
+            }
+        ]
+    }) == "hello\nworld"
+
+
+def test_normalize_ai_json_clamps_confidence():
+    obj = _normalize_ai_json({"has_person": 1, "confidence": 2})
+
+    assert obj["has_person"] is True
+    assert obj["confidence"] == 1.0
+    assert obj["activity"] == "unknown"
+
+
+def test_openai_compatible_client_requires_base_url():
+    with pytest.raises(ValueError):
+        OpenAICompatibleVisionClient(api_key="x", model="m", base_url="")
+
+
+def test_safe_provider_info_hides_api_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    info = safe_provider_info({
+        "ai_provider": "openai",
+        "ai_model": "gpt-vision-test",
+        "ai_request_timeout_sec": 30,
+    })
+
+    assert info["provider"] == "openai"
+    assert info["api_key_set"] is True
+    assert "api_key" not in info
+
+
+def test_openai_compatible_client_can_analyze_frame_against_fake_server():
+    server = _serve_fake_vision()
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}/v1"
+        client = OpenAICompatibleVisionClient(
+            api_key="test-key",
+            model="fake-vision-model",
+            base_url=base_url,
+            timeout_sec=5,
+        )
+
+        frame = np.zeros((16, 16, 3), dtype=np.uint8)
+        result = client.analyze_frame(frame, time_text="2026-05-30 02:33:11")
+
+        assert result["has_person"] is True
+        assert result["person_count"] == 1
+        assert result["activity"] == "standing"
+        assert result["confidence"] == 0.87
+
+        assert _FakeVisionHandler.seen["path"] == "/v1/chat/completions"
+        assert _FakeVisionHandler.seen["auth"] == "Bearer test-key"
+        assert _FakeVisionHandler.seen["model"] == "fake-vision-model"
+        content = _FakeVisionHandler.seen["content"]
+        assert content[0]["type"] == "text"
+        assert content[1]["type"] == "image_url"
+        assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/test_web_model_info.py
+++ b/tests/test_web_model_info.py
@@ -1,0 +1,61 @@
+import logging
+import threading
+
+from app.ai.ai_store import AiRuntime, EventStore
+from app.config.config_store import ConfigStore, DEFAULT_CONFIG
+from app.core.frame_buffer import FrameBuffer
+from app.core.runtime import RecorderRuntime
+from app.core.upload_stats import UploadStats
+from app.web.webapp import create_app
+
+
+def _make_test_client(tmp_path):
+    cfg = DEFAULT_CONFIG.copy()
+    cfg.update({
+        "ai_provider": "openai",
+        "ai_model": "gpt-vision-test",
+        "ai_api_key": "sk-test",
+        "ai_request_timeout_sec": 30,
+    })
+
+    app = create_app(
+        cfg_store=ConfigStore(path=str(tmp_path / "config.json"), initial=cfg),
+        frame_buf=FrameBuffer(),
+        stats=UploadStats(),
+        rec_rt=RecorderRuntime(),
+        ai_rt=AiRuntime(),
+        event_store=EventStore(path=str(tmp_path / "ai_events.jsonl")),
+        logger=logging.getLogger("test-web-model-info"),
+        stop_event=threading.Event(),
+        threads={},
+        server_log_path=str(tmp_path / "server.log"),
+    )
+    return app.test_client()
+
+
+def test_ai_status_includes_safe_model_info(tmp_path):
+    client = _make_test_client(tmp_path)
+
+    resp = client.get("/api/ai/status")
+
+    assert resp.status_code == 200
+    data = resp.get_json()["data"]
+    assert data["model_info"] == {
+        "provider": "openai",
+        "kind": "openai_compatible",
+        "model": "gpt-vision-test",
+        "base_url": "https://api.openai.com/v1",
+        "timeout_sec": 30,
+        "api_key_set": True,
+    }
+
+
+def test_dashboard_has_model_info_container(tmp_path):
+    client = _make_test_client(tmp_path)
+
+    resp = client.get("/dashboard")
+
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'id="aiModelInfo"' in html
+    assert "Model Info" in html


### PR DESCRIPTION
## Summary

- Add a unified visual model provider layer with Ark compatibility and OpenAI-compatible support.
- Add sanitized current model info to the AI status API and Dashboard.
- Update Chinese and English README sections for third-party model integration.
- Add tests for provider resolution, fake OpenAI-compatible model calls, and Dashboard model info rendering.

## Validation

- `python -m pytest -q` -> `12 passed`
- `python -m compileall app server.py tests`

## Notes

- Local-only `CODEX_MODIFICATION_LOG.md` remains ignored by Git.
- `AI_Model_Provider_Module_CN.md` was kept local as a review draft and was not included in this PR.